### PR TITLE
improve individual test matching and output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ async-trait = "0.1"
 console = "0.15"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 glob = "0.3"
+itertools = "0.13"
 libtest-mimic = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlplannertest"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "A yaml-based SQL planner test framework."
 license = "MIT OR Apache-2.0"

--- a/naivedb/Cargo.toml
+++ b/naivedb/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 async-trait = "0.1"
+clap = { version = "4.5", features = ["derive"] }
 sqlplannertest = { path = ".." }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs"] }
 

--- a/naivedb/src/bin/apply.rs
+++ b/naivedb/src/bin/apply.rs
@@ -1,12 +1,31 @@
 use std::path::Path;
 
 use anyhow::Result;
+use clap::Parser;
+use sqlplannertest::PlannerTestApplyOptions;
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Cli {
+    /// Optional list of selections to apply the test; if empty, apply all tests
+    selections: Vec<String>,
+    /// Execute tests in serial
+    #[clap(long)]
+    serial: bool,
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    sqlplannertest::planner_test_apply(
+    let cli = Cli::parse();
+
+    let options = PlannerTestApplyOptions {
+        serial: cli.serial,
+        selections: cli.selections,
+    };
+    sqlplannertest::planner_test_apply_with_options(
         Path::new(env!("CARGO_MANIFEST_DIR")).join("tests"),
         || async { Ok(naivedb::NaiveDb::new()) },
+        options,
     )
     .await?;
     Ok(())

--- a/naivedb/tests/basics/create.planner.sql
+++ b/naivedb/tests/basics/create.planner.sql
@@ -2,6 +2,13 @@
 CREATE TABLE t1(v1 int);
 
 /*
+=== logical
+I'm a naive db, so I don't now how to process
+CREATE TABLE t1(v1 int);
 
+
+=== physical
+I'm a naive db, so I don't now how to process
+CREATE TABLE t1(v1 int);
 */
 

--- a/naivedb/tests/basics/create.planner.sql
+++ b/naivedb/tests/basics/create.planner.sql
@@ -1,0 +1,7 @@
+-- Test whether select stmt works correctly.
+CREATE TABLE t1(v1 int);
+
+/*
+
+*/
+

--- a/naivedb/tests/basics/create.yml
+++ b/naivedb/tests/basics/create.yml
@@ -1,4 +1,6 @@
 - sql: |
     CREATE TABLE t1(v1 int);
   desc: Test whether select stmt works correctly.
-  
+  tasks:
+  - logical
+  - physical

--- a/naivedb/tests/basics/create.yml
+++ b/naivedb/tests/basics/create.yml
@@ -1,3 +1,4 @@
 - sql: |
     CREATE TABLE t1(v1 int);
   desc: Test whether select stmt works correctly.
+  

--- a/naivedb/tests/basics/create.yml
+++ b/naivedb/tests/basics/create.yml
@@ -1,0 +1,3 @@
+- sql: |
+    CREATE TABLE t1(v1 int);
+  desc: Test whether select stmt works correctly.

--- a/naivedb/tests/basics/select.planner.sql
+++ b/naivedb/tests/basics/select.planner.sql
@@ -1,0 +1,7 @@
+-- Test whether select stmt works correctly.
+SELECT * FROM t1;
+
+/*
+
+*/
+

--- a/naivedb/tests/basics/select.planner.sql
+++ b/naivedb/tests/basics/select.planner.sql
@@ -2,6 +2,15 @@
 SELECT * FROM t1;
 
 /*
+=== logical
+I'm a naive db, so I don't now how to process
+CREATE TABLE t1(v1 int);
+SELECT * FROM t1;
 
+
+=== physical
+I'm a naive db, so I don't now how to process
+CREATE TABLE t1(v1 int);
+SELECT * FROM t1;
 */
 

--- a/naivedb/tests/basics/select.yml
+++ b/naivedb/tests/basics/select.yml
@@ -2,3 +2,4 @@
     SELECT * FROM t1;
   desc: Test whether select stmt works correctly.
   before: ["CREATE TABLE t1(v1 int);"]
+  

--- a/naivedb/tests/basics/select.yml
+++ b/naivedb/tests/basics/select.yml
@@ -2,4 +2,6 @@
     SELECT * FROM t1;
   desc: Test whether select stmt works correctly.
   before: ["CREATE TABLE t1(v1 int);"]
-  
+  tasks:
+    - logical
+    - physical

--- a/naivedb/tests/basics/select.yml
+++ b/naivedb/tests/basics/select.yml
@@ -1,0 +1,4 @@
+- sql: |
+    SELECT * FROM t1;
+  desc: Test whether select stmt works correctly.
+  before: ["CREATE TABLE t1(v1 int);"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ fn mk_patterns(path: impl AsRef<Path>, selections: &[String]) -> Vec<String> {
     // Select matching tests.
     selections
         .iter()
-        .map(|s| {
+        .flat_map(|s| {
             let path_segment = s.replace("::", "/");
             // e.g. tests/<..>/path_segment.yml
             let file_match = mk_pattern(format!("**/{path_segment}{}", TEST_SUFFIX));
@@ -96,7 +96,6 @@ fn mk_patterns(path: impl AsRef<Path>, selections: &[String]) -> Vec<String> {
             let module_match = mk_pattern(format!("{path_segment}/**/[!_]*{}", TEST_SUFFIX));
             std::iter::once(file_match).chain(std::iter::once(module_match))
         })
-        .flatten()
         .collect()
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use anyhow::{Context, Result};
 pub use apply::{planner_test_apply, planner_test_apply_with_options, PlannerTestApplyOptions};
 use async_trait::async_trait;
 use glob::Paths;
+use itertools::Itertools;
 use resolve_id::resolve_testcase_id;
 use serde::{Deserialize, Serialize};
 pub use test_runner::planner_test_runner;
@@ -51,12 +52,52 @@ pub fn parse_test_cases(
 const TEST_SUFFIX: &str = ".yml";
 const RESULT_SUFFIX: &str = "planner.sql";
 
-pub fn discover_tests(path: impl AsRef<Path>) -> Result<Paths> {
-    let pattern = format!("**/[!_]*{}", TEST_SUFFIX);
-    let path = path.as_ref().join(pattern);
-    let path = path.to_str().context("non utf-8 path")?;
-    let paths = glob::glob(path).context("failed to discover test")?;
-    Ok(paths)
+pub fn discover_tests(path: impl AsRef<Path>) -> Result<impl Iterator<Item = glob::GlobResult>> {
+    discover_tests_with_selections(path, &[])
+}
+
+pub fn discover_tests_with_selections(
+    path: impl AsRef<Path>,
+    selections: &[String],
+) -> Result<impl Iterator<Item = glob::GlobResult>> {
+    let patterns = mk_patterns(&path, selections);
+    let paths: Vec<Paths> = patterns
+        .into_iter()
+        .map(|pattern| glob::glob(&pattern).context("input pattern is invalid"))
+        .try_collect()?;
+
+    Ok(paths.into_iter().flatten())
+}
+
+/// Make glob patterns based on `selections`.
+///
+/// If `selections` is empty, returns the glob pattern that select all tests within `path`.
+/// Otherwise returns the glob pattterns that matches the selected test modules or files.
+fn mk_patterns(path: impl AsRef<Path>, selections: &[String]) -> Vec<String> {
+    let mk_pattern = |glob: String| {
+        let path = path.as_ref().join(glob);
+        path.to_str().expect("non utf-8 path").to_string()
+    };
+
+    if selections.is_empty() {
+        // Select all tests
+        return vec![mk_pattern(format!("**/[!_]*{}", TEST_SUFFIX))];
+    }
+
+    // Select matching tests.
+    selections
+        .iter()
+        .map(|s| {
+            let path_segment = s.replace("::", "/");
+            // e.g. tests/<..>/path_segment.yml
+            let file_match = mk_pattern(format!("**/{path_segment}{}", TEST_SUFFIX));
+            // Module match, needs to start at the top level.
+            // e.g. tests/path_segment/<..>/<some>.yml
+            let module_match = mk_pattern(format!("{path_segment}/**/[!_]*{}", TEST_SUFFIX));
+            std::iter::once(file_match).chain(std::iter::once(module_match))
+        })
+        .flatten()
+        .collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Adding the ability to match selected test modules or files. Also display test names with module hierarchy.

- can match globs in planner test apply.
- show module hierarchy in both apply + tests.

**Before**

<pre>
$ cargo run -p naivedb --bin apply
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/apply`
[DONE] ok.yml, took 1 ms
[DONE] error.yml, took 1 ms

$ cargo nextest run -p naivedb ok
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.02s
------------
 Nextest run ID 44de9a31-bc77-41c3-90d5-def47c4694dd with nextest profile: default
    Starting 1 test across 3 binaries (1 test skipped)
        PASS [   0.005s] naivedb::plannertest ok
------------
     Summary [   0.005s] 1 test run: 1 passed, 1 skipped
</pre>

**After**
<pre>
$ cargo run -p naivedb --bin apply -- basics ok
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/apply basics ok`
<b>[DONE] basics/create.yml, took 1 ms</b>
<b>[DONE] basics/select.yml, took 1 ms</b>
[DONE] ok.yml, took 1 ms

$ cargo nextest run -p naivedb <b>basics::create ok</b>
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.02s
------------
 Nextest run ID 3789c774-11bc-4d06-98ec-2d8dde74789e with nextest profile: default
    Starting 2 tests across 3 binaries (2 tests skipped)
        PASS [   0.005s] naivedb::plannertest <b>basics::create</b>
        PASS [   0.004s] naivedb::plannertest ok
------------
     Summary [   0.005s] 2 tests run: 2 passed, 2 skipped
</pre>


